### PR TITLE
Introduce SpacyModelFileStorePortObject for workflow portability

### DIFF
--- a/se.redfield.textprocessing/plugin.xml
+++ b/se.redfield.textprocessing/plugin.xml
@@ -87,6 +87,24 @@
                specClass="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec"
                specSerializer="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec$Serializer">
          </portType>
+         <portType
+               color="#09a4d7"
+               hidden="false"
+               name="spaCy pipeline"
+               objectClass="se.redfield.textprocessing.nodes.port.SpacyModelFileStorePortObject"
+               objectSerializer="se.redfield.textprocessing.nodes.port.SpacyModelFileStorePortObject$Serializer"
+               specClass="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec"
+               specSerializer="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec$Serializer">
+         </portType>
+         <portType
+               color="#09a4d7"
+               hidden="false"
+               name="spaCy pipeline"
+               objectClass="se.redfield.textprocessing.nodes.port.ISpacyModelPortObject"
+               objectSerializer="se.redfield.textprocessing.nodes.port.ISpacyModelPortObject$Serializer"
+               specClass="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec"
+               specSerializer="se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec$Serializer">
+         </portType>
       </extension>
    
 </plugin>

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/core/SpacyDocumentProcessor.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/core/SpacyDocumentProcessor.java
@@ -33,4 +33,9 @@ public interface SpacyDocumentProcessor {
 	 * @param builder The tag builder.
 	 */
 	public void setTagBuilder(TagBuilder builder);
+	
+	/**
+	 * @return the type of tags produced by this model (e.g. POS)
+	 */
+	public String getTagType();
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/core/model/SpacyModelDescription.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/core/model/SpacyModelDescription.java
@@ -3,6 +3,7 @@
 */
 package se.redfield.textprocessing.core.model;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -68,7 +69,7 @@ public class SpacyModelDescription {
 			features = null;
 		}
 	}
-
+	
 	/**
 	 * @return The model download path.
 	 */
@@ -81,5 +82,12 @@ public class SpacyModelDescription {
 	 */
 	public Set<SpacyFeature> getFeatures() {
 		return features;
+	}
+	
+	/**
+	 * @return the name of the model
+	 */
+	public String getName() {
+		return Path.of(path).getFileName().toString();
 	}
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/data/tag/DynamicTagBuilder.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/data/tag/DynamicTagBuilder.java
@@ -4,7 +4,6 @@
 package se.redfield.textprocessing.data.tag;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.knime.ext.textprocessing.data.TagBuilder;
 import org.knime.ext.textprocessing.data.tag.TagSet;
@@ -18,26 +17,14 @@ import org.knime.ext.textprocessing.data.tag.TagSet;
  *
  */
 public class DynamicTagBuilder extends GenericTagBuilder {
-	private static final String TAG_TYPE_PREFIX = "SPACY_";
-
 	/**
 	 * @param registeredTagSets Tag sets already registered.
 	 * @param tags              The list of tags.
+	 * @param modelName         The name of the model that produced the tags
+	 * @param tagType           The type of tag (e.g. POS)
 	 */
-	public DynamicTagBuilder(Set<TagSet> registeredTagSets, Set<String> tags) {
-		super(buildTagType(registeredTagSets), tags);
-	}
-
-	private static String buildTagType(Set<TagSet> registeredTagSets) {
-		Set<String> registeredNames = registeredTagSets.stream().map(TagSet::getType).collect(Collectors.toSet());
-
-		int idx = 0;
-		String type = null;
-		do {
-			type = TAG_TYPE_PREFIX + idx++;
-		} while (registeredNames.contains(type));
-
-		return type;
+	public DynamicTagBuilder(Set<TagSet> registeredTagSets, Set<String> tags, String modelName, String tagType) {
+		super(String.format("SPACY_%s_%s", tagType, modelName), tags);
 	}
 
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyBaseNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyBaseNodeModel.java
@@ -41,7 +41,7 @@ import org.knime.python2.kernel.PythonIOException;
 
 import se.redfield.textprocessing.core.PythonContext;
 import se.redfield.textprocessing.core.model.SpacyFeature;
-import se.redfield.textprocessing.nodes.port.SpacyModelPortObject;
+import se.redfield.textprocessing.nodes.port.ISpacyModelPortObject;
 import se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec;
 
 /**
@@ -66,8 +66,8 @@ public abstract class SpacyBaseNodeModel extends NodeModel {
 	private final boolean acceptStringColumn;
 
 	protected SpacyBaseNodeModel(SpacyNodeSettings settings, boolean acceptStringColumn) {
-		super(new PortType[] { SpacyModelPortObject.TYPE, BufferedDataTable.TYPE },
-				new PortType[] { SpacyModelPortObject.TYPE, BufferedDataTable.TYPE });
+		super(new PortType[] { ISpacyModelPortObject.TYPE, BufferedDataTable.TYPE },
+				new PortType[] { ISpacyModelPortObject.TYPE, BufferedDataTable.TYPE });
 		this.settings = settings;
 		this.acceptStringColumn = acceptStringColumn;
 	}
@@ -148,7 +148,7 @@ public abstract class SpacyBaseNodeModel extends NodeModel {
 
 	@Override
 	protected PortObject[] execute(PortObject[] inData, ExecutionContext exec) throws Exception {
-		SpacyModelPortObject model = (SpacyModelPortObject) inData[PORT_MODEL];
+		ISpacyModelPortObject model = (ISpacyModelPortObject) inData[PORT_MODEL];
 		BufferedDataTable inTable = (BufferedDataTable) inData[PORT_TABLE];
 		exec.setMessage("spaCy");
 

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyDocumentProcessorNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyDocumentProcessorNodeModel.java
@@ -51,7 +51,7 @@ public abstract class SpacyDocumentProcessorNodeModel extends SpacyBaseNodeModel
 
 	@Override
 	protected CellFactory createCellFactory(int inputColumn, int resultColumn, DataTableSpec inSpec,
-			BufferedDataTable metaTable, ExecutionContext exec) throws CanceledExecutionException {
+			BufferedDataTable metaTable, ExecutionContext exec, String modelName) throws CanceledExecutionException {
 		TextContainerDataCellFactory textContainerFactory = createTextContainerFactory(exec);
 
 		DataColumnSpecCreator creator = new DataColumnSpecCreator(settings.getOutputColumnName(),
@@ -63,7 +63,7 @@ public abstract class SpacyDocumentProcessorNodeModel extends SpacyBaseNodeModel
 
 		if (docProcessor.getTagBuilder() != null) {
 			Set<String> tags = collectAssignedTags(metaTable, exec);
-			TagBuilder builder = selectTagBuilder(tags, docProcessor.getTagBuilder(), dynamicTagSets);
+			TagBuilder builder = selectTagBuilder(tags, docProcessor, dynamicTagSets, modelName);
 			docProcessor.setTagBuilder(builder);
 
 			if (builder instanceof DynamicTagBuilder) {
@@ -87,8 +87,9 @@ public abstract class SpacyDocumentProcessorNodeModel extends SpacyBaseNodeModel
 		return tags;
 	}
 
-	private static TagBuilder selectTagBuilder(Set<String> tags, TagBuilder staticBuilder,
-			Set<TagSet> availableTagSets) {
+	private static TagBuilder selectTagBuilder(Set<String> tags, SpacyDocumentProcessor docProcessor,
+			Set<TagSet> availableTagSets, String modelName) {
+		var staticBuilder = docProcessor.getTagBuilder();
 		if (tags.stream().allMatch(t -> staticBuilder.buildTag(t) != null)) {
 			return staticBuilder;
 		}
@@ -100,7 +101,7 @@ public abstract class SpacyDocumentProcessorNodeModel extends SpacyBaseNodeModel
 			}
 		}
 
-		return new DynamicTagBuilder(availableTagSets, tags);
+		return new DynamicTagBuilder(availableTagSets, tags, modelName, docProcessor.getTagType());
 	}
 
 	protected abstract SpacyDocumentProcessor createSpacyDocumentProcessor();

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/lemmatizer/SpacyLemmatizerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/lemmatizer/SpacyLemmatizerNodeModel.java
@@ -93,5 +93,10 @@ public class SpacyLemmatizerNodeModel extends SpacyDocumentProcessorNodeModel {
 			return new Sentence(terms);
 		}
 
+		@Override
+		public String getTagType() {
+			return "LEMMA";
+		}
+
 	}
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/morph/SpacyMorphologizerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/morph/SpacyMorphologizerNodeModel.java
@@ -60,5 +60,10 @@ public class SpacyMorphologizerNodeModel extends SpacyDocumentProcessorNodeModel
 			return tags;
 		}
 
+		@Override
+		public String getTagType() {
+			return "MORPH";
+		}
+
 	}
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/ner/SpacyNerTaggerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/ner/SpacyNerTaggerNodeModel.java
@@ -171,5 +171,10 @@ public class SpacyNerTaggerNodeModel extends SpacyDocumentProcessorNodeModel {
 			return new Sentence(terms);
 		}
 
+		@Override
+		public String getTagType() {
+			return "NE";
+		}
+
 	}
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/ISpacyModelPortObject.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/ISpacyModelPortObject.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.textprocessing.nodes.port;
+
+import java.io.IOException;
+
+import org.knime.core.node.CanceledExecutionException;
+import org.knime.core.node.ExecutionMonitor;
+import org.knime.core.node.port.PortObject;
+import org.knime.core.node.port.PortObjectSpec;
+import org.knime.core.node.port.PortObjectZipInputStream;
+import org.knime.core.node.port.PortObjectZipOutputStream;
+import org.knime.core.node.port.PortType;
+import org.knime.core.node.port.PortTypeRegistry;
+
+/**
+ * Common interface of PortObjects holding spaCy models.
+ * 
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
+ */
+public interface ISpacyModelPortObject extends PortObject {
+
+	/**
+	 * The common PortType of implementing PortObjects.
+	 */
+	public static PortType TYPE = PortTypeRegistry.getInstance().getPortType(ISpacyModelPortObject.class);
+
+	@Override
+	SpacyModelPortObjectSpec getSpec();
+
+	@Override
+	default String getSummary() {
+		return getSpec().toString();
+	}
+
+	/**
+	 * @return the local path to the model
+	 */
+	String getModelPath();
+
+	/**
+	 * Serializer of ISpacyModelPortObject. All methods raise an
+	 * IllegalStateException because @link ISpacyModelPortObject is an interface and
+	 * only implementing classes should ever be serialized.
+	 */
+	public static final class Serializer extends PortObjectSerializer<ISpacyModelPortObject> {
+
+		@Override
+		public void savePortObject(final ISpacyModelPortObject portObject, final PortObjectZipOutputStream out,
+				final ExecutionMonitor exec) throws IOException, CanceledExecutionException {
+			throw new IllegalStateException(
+					"Serializing ISpacyModelPortObject is unsupported. Implement a serializer for the implementing type.");
+		}
+
+		@Override
+		public ISpacyModelPortObject loadPortObject(final PortObjectZipInputStream in, final PortObjectSpec spec,
+				final ExecutionMonitor exec) throws IOException, CanceledExecutionException {
+			throw new IllegalStateException(
+					"Deserializing ISpacyModelPortObject is unsupported. Implement a serializer for the implementing type.");
+		}
+	}
+
+}

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/SpacyModelFileStorePortObject.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/SpacyModelFileStorePortObject.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2021 Redfield AB.
+*/
+package se.redfield.textprocessing.nodes.port;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.swing.JComponent;
+
+import org.knime.core.data.filestore.FileStore;
+import org.knime.core.data.filestore.FileStoreFactory;
+import org.knime.core.data.filestore.FileStorePortObject;
+import org.knime.core.node.CanceledExecutionException;
+import org.knime.core.node.ExecutionMonitor;
+import org.knime.core.node.port.PortObjectSpec;
+import org.knime.core.node.port.PortObjectZipInputStream;
+import org.knime.core.node.port.PortObjectZipOutputStream;
+
+/**
+ * Filestore based PortObject for SpacyModels. Such a PortObject makes the model
+ * part of the workflow and enables sharing the workflow in a partially executed
+ * state or deploying the model to a remote executor via Integrated Deployment.
+ * 
+ * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
+ */
+public final class SpacyModelFileStorePortObject extends FileStorePortObject implements ISpacyModelPortObject {
+
+	private final SpacyModelPortObjectSpec m_spec;
+	
+	/**
+	 * Creates a new SpacyModelFileStorePortObject.
+	 * 
+	 * @param spec of the model
+	 * @param fsFactory for creating the FileStore
+	 * @return the port object containing the model
+	 * @throws IOException if copying the model into the FileStore fails
+	 */
+	public static SpacyModelFileStorePortObject create(final SpacyModelPortObjectSpec spec,
+			final FileStoreFactory fsFactory) throws IOException {
+		var modelPath = Path.of(spec.getModel().getPath());
+		var modelName = modelPath.getFileName().toString();
+		var fileStore = fsFactory.createFileStore(modelName);
+		copyModelIntoFileStore(modelPath, fileStore.getFile().toPath());
+		return new SpacyModelFileStorePortObject(spec, fileStore);
+	}
+
+	private static void copyModelIntoFileStore(final Path modelPath, final Path fileStorePath) throws IOException {
+		try (var fileStream = Files.walk(modelPath)) {
+			fileStream.forEach(source -> {
+				var destination = fileStorePath.resolve(modelPath.relativize(source));
+				try {
+					Files.copy(source, destination);
+				} catch (IOException e) {
+					throw new CopyException(e);
+				}
+			});
+		} catch (CopyException ex) {
+			throw ex.getCause();
+		}
+	}
+
+	/**
+	 * Constructor for creating new models.
+	 * 
+	 * @param spec of the model
+	 * @param fileStore the model is stored in
+	 */
+	private SpacyModelFileStorePortObject(final SpacyModelPortObjectSpec spec, final FileStore fileStore) {
+		super(List.of(fileStore));
+		m_spec = spec;
+	}
+	
+	private SpacyModelFileStorePortObject(SpacyModelPortObjectSpec spec) {
+		super();
+		m_spec = spec;
+	}
+
+	private static final class CopyException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
+
+		CopyException(final IOException cause) {
+			super(cause);
+		}
+
+		@Override
+		public synchronized IOException getCause() {
+			return (IOException) super.getCause();
+		}
+
+	}
+	
+	@Override
+	public String getModelPath() {
+		return getFileStore(0).getFile().getAbsolutePath();
+	}
+
+	@Override
+	public SpacyModelPortObjectSpec getSpec() {
+		return m_spec;
+	}
+
+	@Override
+	public JComponent[] getViews() {
+		return null; // NOSONAR
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == this) {
+			return true;
+		} else if (obj instanceof SpacyModelFileStorePortObject) {
+			var other = (SpacyModelFileStorePortObject)obj;
+			return m_spec.equals(other.m_spec) && super.equals(obj);
+		} else {
+			return false;
+		}
+	}
+	
+	@Override
+	public int hashCode() {
+		return super.hashCode();
+	}
+	
+	/**
+	 * Serializer for the SpacyModelFileStorePortObject.
+	 * Doesn't actually serialize everything because all information is in the FileStore.
+	 * 
+	 * @author Adrian Nembach, KNIME GmbH, Konstanz, Germany
+	 */
+	public static final class Serializer extends PortObjectSerializer<SpacyModelFileStorePortObject> {
+
+		@Override
+		public void savePortObject(SpacyModelFileStorePortObject portObject, PortObjectZipOutputStream out,
+				ExecutionMonitor exec) throws IOException, CanceledExecutionException {
+			// nothing to save
+		}
+
+		@Override
+		public SpacyModelFileStorePortObject loadPortObject(PortObjectZipInputStream in, PortObjectSpec spec,
+				ExecutionMonitor exec) throws IOException, CanceledExecutionException {
+			return new SpacyModelFileStorePortObject((SpacyModelPortObjectSpec)spec);
+		}
+		
+	}
+
+}

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/SpacyModelPortObject.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/port/SpacyModelPortObject.java
@@ -17,9 +17,10 @@ import org.knime.core.node.port.PortTypeRegistry;
  * The SpaCy model port object.
  * 
  * @author Alexander Bondaletov
- *
+ * @deprecated use {@link SpacyModelFileStorePortObject} instead
  */
-public class SpacyModelPortObject extends AbstractSimplePortObject {
+@Deprecated
+public class SpacyModelPortObject extends AbstractSimplePortObject implements ISpacyModelPortObject {
 
 	/**
 	 * Serializer for the {@link SpacyModelPortObject}.

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/pos/SpacyPosTaggerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/pos/SpacyPosTaggerNodeModel.java
@@ -58,5 +58,10 @@ public class SpacyPosTaggerNodeModel extends SpacyDocumentProcessorNodeModel {
 				return Collections.emptyList();
 			}
 		}
+
+		@Override
+		public String getTagType() {
+			return "POS";
+		}
 	}
 }

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/selector/SpacyModelSelectorNodeFactory.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/selector/SpacyModelSelectorNodeFactory.java
@@ -11,7 +11,7 @@ import org.knime.core.node.NodeView;
 import org.knime.core.node.context.NodeCreationConfiguration;
 import org.knime.filehandling.core.port.FileSystemPortObject;
 
-import se.redfield.textprocessing.nodes.port.SpacyModelPortObject;
+import se.redfield.textprocessing.nodes.port.ISpacyModelPortObject;
 
 /**
  * The factory class for the {@link SpacyModelSelectorNodeModel} node.
@@ -30,7 +30,7 @@ public class SpacyModelSelectorNodeFactory extends ConfigurableNodeFactory<Spacy
 	protected Optional<PortsConfigurationBuilder> createPortsConfigBuilder() {
 		PortsConfigurationBuilder builder = new PortsConfigurationBuilder();
 		builder.addOptionalInputPortGroup(FILE_SYSTEM_CONNECTION_PORT_NAME, FileSystemPortObject.TYPE);
-		builder.addFixedOutputPortGroup("Spacy Model", SpacyModelPortObject.TYPE);
+		builder.addFixedOutputPortGroup("Spacy Model", ISpacyModelPortObject.TYPE);
 		return Optional.of(builder);
 	}
 

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/selector/SpacyModelSelectorNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/selector/SpacyModelSelectorNodeModel.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.EnumSet;
 
+import org.knime.core.data.filestore.FileStoreFactory;
 import org.knime.core.node.CanceledExecutionException;
 import org.knime.core.node.ExecutionContext;
 import org.knime.core.node.ExecutionMonitor;
@@ -24,7 +25,7 @@ import se.redfield.textprocessing.core.model.SpacyModelDescription;
 import se.redfield.textprocessing.core.model.download.FsModelDownloader;
 import se.redfield.textprocessing.core.model.download.RepositoryModelDownloader;
 import se.redfield.textprocessing.core.model.download.SpacyModelDownloader;
-import se.redfield.textprocessing.nodes.port.SpacyModelPortObject;
+import se.redfield.textprocessing.nodes.port.SpacyModelFileStorePortObject;
 import se.redfield.textprocessing.nodes.port.SpacyModelPortObjectSpec;
 import se.redfield.textprocessing.nodes.selector.SpacyModelSelectorNodeSettings.SpacyModelSelectionMode;
 
@@ -62,7 +63,9 @@ public class SpacyModelSelectorNodeModel extends NodeModel {
 	protected PortObject[] execute(PortObject[] inObjects, ExecutionContext exec) throws Exception {
 		SpacyModelDownloader downloader = createDownloader();
 		downloader.ensureDownloaded(exec);
-		return new PortObject[] { new SpacyModelPortObject(createSpec(downloader.getModelDescription(false))) };
+		final var spec = createSpec(downloader.getModelDescription(false));
+		var model = SpacyModelFileStorePortObject.create(spec, FileStoreFactory.createFileStoreFactory(exec));
+		return new PortObject[] { model };
 	}
 
 	private SpacyModelDownloader createDownloader() {

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/tokenizer/SpacyTokenizerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/tokenizer/SpacyTokenizerNodeModel.java
@@ -60,7 +60,7 @@ public class SpacyTokenizerNodeModel extends SpacyBaseNodeModel {
 
 	@Override
 	protected CellFactory createCellFactory(int inputColumn, int resultColumn, DataTableSpec inSpec,
-			BufferedDataTable metaTable, ExecutionContext exec) {
+			BufferedDataTable metaTable, ExecutionContext exec, String modelName) {
 		return new DocumentCellFactory(createOutputColumnSpec(), createTextContainerFactory(exec), resultColumn);
 	}
 

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/vectorizer/SpacyVectorizerNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/vectorizer/SpacyVectorizerNodeModel.java
@@ -50,8 +50,8 @@ public class SpacyVectorizerNodeModel extends SpacyBaseNodeModel {
 	}
 
 	@Override
-	protected BufferedDataTable buildOutputTable(BufferedDataTable inTable, PythonContext ctx, ExecutionContext exec)
-			throws CanceledExecutionException, PythonIOException {
+	protected BufferedDataTable buildOutputTable(BufferedDataTable inTable, PythonContext ctx, ExecutionContext exec,
+			String modelName) throws CanceledExecutionException, PythonIOException {
 		BufferedDataTable res = ctx.getDataTable(exec.createSubExecutionContext(0.5));
 		BufferedDataTable joined = joinResultTable(inTable, res, exec.createSubExecutionContext(0.5));
 
@@ -79,7 +79,7 @@ public class SpacyVectorizerNodeModel extends SpacyBaseNodeModel {
 
 	@Override
 	protected CellFactory createCellFactory(int inputColumn, int resultColumn, DataTableSpec inSpec,
-			BufferedDataTable metaTable, ExecutionContext exec) {
+			BufferedDataTable metaTable, ExecutionContext exec, String modelName) {
 		return null;
 	}
 


### PR DESCRIPTION
The old PortObject implementation referenced the model in the cache
which didn't exist on another machine. The new PortObject stores the
model in a FileStore that is part of the workflow and therefore can be
shared alongside the workflow.