### PR TITLE
Adapt to backend changes

### DIFF
--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/core/PythonContext.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/core/PythonContext.java
@@ -57,7 +57,6 @@ public class PythonContext implements AutoCloseable {
 		try {
 			PythonKernel kernel = PythonKernelQueue.getNextKernel(command, PythonKernelBackendType.PYTHON3,
 					Collections.emptySet(), Collections.emptySet(), options, PythonCancelable.NOT_CANCELABLE);
-			kernel.execute("import knime_io as knio");
 			kernel.execute(setupPythonPath());
 			return kernel;
 		} catch (PythonIOException e) {
@@ -144,7 +143,8 @@ public class PythonContext implements AutoCloseable {
 	public void executeInKernel(String code, ExecutionMonitor exec)
 			throws PythonIOException, CanceledExecutionException {
 		progressListener.setMonitor(exec);
-		kernel.execute(code, new PythonExecutionMonitorCancelable(exec));
+		// we need to check the outputs in order for them to being actually written
+		kernel.executeAndCheckOutputs(code, new PythonExecutionMonitorCancelable(exec));
 		progressListener.setMonitor(null);
 		exec.setProgress(1.0);
 	}

--- a/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyBaseNodeModel.java
+++ b/se.redfield.textprocessing/src/se/redfield/textprocessing/nodes/base/SpacyBaseNodeModel.java
@@ -237,6 +237,7 @@ public abstract class SpacyBaseNodeModel extends NodeModel {
 
 	private String createExecuteScript(String modelPath) {
 		DLPythonSourceCodeBuilder b = DLPythonUtils.createSourceCodeBuilder("from SpacyNlp import " + getSpacyMethod());
+		b.a("import knime.scripting.io as knio").n();
 		b.a(getSpacyMethod()).a(".run(").n();
 		b.a("model_handle = ").asr(modelPath).a(",").n();
 		PythonContext.putInputTableArgs(b, "input_table", 0);


### PR DESCRIPTION
This PR adapts to changes related to the Python backend that were introduced in KNIME AP 4.7.0.
As part of it I also switched to the new API that was introduced which among other things allows to generate row keys for output tables.